### PR TITLE
Allow hiding the toolbar for kiosk displays

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,7 @@ width = 640
 height = 480
 use_gles = true            # request an OpenGL ES context (required on Mali handhelds)
 cursor_linger_ms = 1500    # how long the cursor stays visible after moving
+toolbar_visible = true     # false hides browser chrome for kiosk-style displays
 toolbar_position = "top"   # which edge the toolbar sits on: "top" or "bottom"
 toolbar_autohide = false   # hide on scroll down, reveal on scroll up (top reflows, bottom overlays)
 

--- a/src/app/execute.rs
+++ b/src/app/execute.rs
@@ -282,6 +282,8 @@ impl App {
         self.ui
             .set_toolbar_position(self.config.display.toolbar_position);
         self.ui
+            .set_toolbar_visible(self.config.display.toolbar_visible);
+        self.ui
             .set_toolbar_autohide(self.config.display.toolbar_autohide);
         self.ui.set_hint_badges(self.config.input.hint_badges);
         self.ui.menu.history_mut().set_config(&self.config.history);

--- a/src/config/display.rs
+++ b/src/config/display.rs
@@ -17,6 +17,8 @@ pub struct DisplayConfig {
     pub cursor_linger_ms: u64,
     /// Which edge the toolbar (address bar + nav buttons) sits on.
     pub toolbar_position: ToolbarPosition,
+    /// Whether the toolbar is available. Disable it for kiosk-style displays.
+    pub toolbar_visible: bool,
     /// Hide the toolbar while scrolling down, reveal it on scrolling up. A top
     /// toolbar reserves space when shown (the page reflows below it, so the bar
     /// never covers content); a bottom toolbar floats over the page and slides away.
@@ -31,8 +33,20 @@ impl Default for DisplayConfig {
             use_gles: true,
             cursor_linger_ms: 1500,
             toolbar_position: ToolbarPosition::Top,
+            toolbar_visible: true,
             toolbar_autohide: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DisplayConfig;
+
+    #[test]
+    fn toolbar_can_be_disabled() {
+        let config: DisplayConfig = toml::from_str("toolbar_visible = false").unwrap();
+        assert!(!config.toolbar_visible);
     }
 }
 

--- a/src/overlay/settings/fields.rs
+++ b/src/overlay/settings/fields.rs
@@ -216,6 +216,7 @@ pub(super) static FIELDS: &[Field] = &[
     f(S::Display,  "Display",     "Window height",          int!(display.height as u32, bounds::HEIGHT, 16), true),
     f(S::Display,  "Display",     "Use OpenGL ES",          flag!(display.use_gles), true),
     f(S::Display,  "Display",     "Cursor linger (ms)",     int!(display.cursor_linger_ms as u64, bounds::CURSOR_LINGER_MS, 100), false),
+    f(S::Display,  "Display",     "Show toolbar",           flag!(display.toolbar_visible), false),
     f(S::Display,  "Display",     "Toolbar position",       choice!(display.toolbar_position: ToolbarPosition), false),
     f(S::Display,  "Display",     "Auto-hide toolbar",      flag!(display.toolbar_autohide), false),
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -174,6 +174,8 @@ pub struct AppUi {
     cursor_linger: Duration,
     /// Which edge the toolbar renders on (from the display config). Applied live.
     toolbar_position: ToolbarPosition,
+    /// Whether the toolbar is available (from the display config).
+    toolbar_visible: bool,
     /// Whether the toolbar hides on scroll-down / reveals on scroll-up (config).
     toolbar_autohide: bool,
     /// Auto-hide target visibility: shown after a scroll up, hidden after a scroll
@@ -275,6 +277,7 @@ impl AppUi {
             cursor_last_move: None,
             cursor_linger: Duration::from_millis(display.cursor_linger_ms),
             toolbar_position: display.toolbar_position,
+            toolbar_visible: display.toolbar_visible,
             toolbar_autohide: display.toolbar_autohide,
             toolbar_shown: true,
             scroll_accum: 0.0,
@@ -536,6 +539,12 @@ impl AppUi {
     #[inline]
     pub fn set_toolbar_position(&mut self, pos: ToolbarPosition) {
         self.toolbar_position = pos;
+    }
+
+    /// Enable/disable the toolbar (the app calls this on a live config change).
+    #[inline]
+    pub fn set_toolbar_visible(&mut self, visible: bool) {
+        self.toolbar_visible = visible;
     }
 
     /// Enable/disable scroll-driven auto-hide (the app calls this on a live config
@@ -921,7 +930,9 @@ impl AppUi {
         // A bottom auto-hide bar floats as an overlay, so the web view is
         // full-height; every other case reserves a strip (and the measured height
         // is already 0 when a top auto-hide bar is hidden away).
-        let overlay = self.toolbar_autohide && self.toolbar_position == ToolbarPosition::Bottom;
+        let overlay = self.toolbar_visible
+            && self.toolbar_autohide
+            && self.toolbar_position == ToolbarPosition::Bottom;
         let toolbar_px = if overlay {
             0
         } else {
@@ -1024,8 +1035,10 @@ impl AppUi {
         let typing = self.focus() != Focus::Page;
         ToolbarLayout {
             position: self.toolbar_position,
-            shown: !self.toolbar_autohide || self.toolbar_shown || typing,
-            overlay: self.toolbar_autohide && self.toolbar_position == ToolbarPosition::Bottom,
+            shown: self.toolbar_visible && (!self.toolbar_autohide || self.toolbar_shown || typing),
+            overlay: self.toolbar_visible
+                && self.toolbar_autohide
+                && self.toolbar_position == ToolbarPosition::Bottom,
         }
     }
 


### PR DESCRIPTION
Adds a `display.toolbar_visible` setting for kiosk/thin-client use cases. When disabled, the web viewport uses the full display while controller shortcuts and Settings remain available.

Includes a config parsing test and documentation.